### PR TITLE
Added a filter for honeypots.

### DIFF
--- a/doc/usage/web-ui.rst
+++ b/doc/usage/web-ui.rst
@@ -138,6 +138,7 @@ Filters
 
 - ``[!]host:[IP address]`` filter a specific IP address. Using the IP
   address directly (without ``host:``) is equivalent.
+- ``[!]honeypot`` filter for results that are labelled as a honeypot.
 - ``[!]net:[IP address/netmask]`` filter a specific network (CIDR
   notation). Using the CIDR notation directly (without ``net:``) is
   equivalent.

--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -2409,6 +2409,11 @@ class MongoDBActive(MongoDB, DBActive):
         return {"ports.state_state": {"$nin": ["open"]} if neg else "open"}
 
     @staticmethod
+    def searchhoneypot(neg=False):
+        "Filters records that are labelled with honeypot."
+        return {"synack_honeypot": {"$exists": False} if neg else {"$exists": True}}
+
+    @staticmethod
     def searchservice(srv, port=None, protocol=None):
         """Search an open port with a particular service. False means the
         service is unknown.

--- a/ivre/db/mongo.py
+++ b/ivre/db/mongo.py
@@ -2411,7 +2411,7 @@ class MongoDBActive(MongoDB, DBActive):
     @staticmethod
     def searchhoneypot(neg=False):
         "Filters records that are labelled with honeypot."
-        return {"synack_honeypot": {"$exists": False} if neg else {"$exists": True}}
+        return {"synack_honeypot": {"$exists": False} if neg else True}
 
     @staticmethod
     def searchservice(srv, port=None, protocol=None):

--- a/ivre/web/utils.py
+++ b/ivre/web/utils.py
@@ -257,6 +257,8 @@ def flt_from_query(dbase, query, base_flt=None):
             flt = dbase.flt_and(
                 flt, dbase.searchobjectid(value.replace("-", ",").split(","), neg=neg)
             )
+        elif param == "honeypot":
+            flt = dbase.flt_and(flt, dbase.searchhoneypot(neg=neg))
         elif param == "host":
             flt = dbase.flt_and(flt, dbase.searchhost(value, neg=neg))
         elif param == "net":

--- a/web/static/ivre/content.js
+++ b/web/static/ivre/content.js
@@ -104,6 +104,10 @@ var HELP_FILTERS = {
 	    "title": "<b>(!)</b>hostname:<b>[FQDN]</b>",
 	    "content": "Look for results with a matching hostname ([FQDN] can be specified as the exact value or a /regexp/).",
 	},
+	"honeypot:": {
+	 	"title": "<b>(!)</b>honeypot",
+		"content": "Look for hosts that are possibly a honeypot.",
+	},
 	"domain:": {
 	    "title": "<b>(!)</b>domain:<b>[FQDN]</b>",
 	    "content": "Look for results with a hostname within a matching domain name ([FQDN] can be specified as the exact value or a /regexp/).",


### PR DESCRIPTION
This is a filter that shows hosts that have been labelled as a honeypot. Only works for MongoDB databases and no tests have been made for this.