### PR TITLE
Add STUN to zeek passiverecon script

### DIFF
--- a/ivre/passive.py
+++ b/ivre/passive.py
@@ -355,6 +355,8 @@ def _prepare_rec(spec, ignorenets, neverignore):
                             "service_extrainfo": "UDP payload %s" % payload,
                         }
                     )
+    elif spec["recontype"] == "STUN_HONEYPOT_REQUEST":
+        spec["value"] = utils.nmap_decode_data(spec["value"])
     # SSL_{CLIENT,SERVER} JA3
     elif (spec["recontype"] == "SSL_CLIENT" and spec["source"] == "ja3") or (
         spec["recontype"] == "SSL_SERVER" and spec["source"].startswith("ja3-")

--- a/ivre/view.py
+++ b/ivre/view.py
@@ -627,23 +627,22 @@ def _extract_passive_STUN_HONEYPOT_REQUEST(rec):
     except ValueError:
         utils.LOGGER.warning("Cannot parse record [%r]", rec)
         return {}
-    # hack to be MongoDB-compatible
-    tid_lo = tid_lo & 0x7FFFFFFFFFFFFFFF
+    # store TID as string
+    tid = "%016x%016x" % (tid_hi, tid_lo)
     # special case when first int of tid is magic
     if tid_hi >> 32 == 0x2112A442:
         magic = 0x2112A442
     else:
         magic = None
-    output = "Scanned port: %s: %d\nSTUN request (%stid [lower QWORD]: 0x%x)" % (
+    output = "Scanned port: %s: %d\nSTUN request (%stid: %s)" % (
         proto,
         port,
-        # only the lower QWORD of tid because Mongo does not handle 128bit integers
         ("magic: 0x%08x, " % magic) if magic else "",
-        tid_lo,
+        tid,
     )
     structured_output = {
         "ports": {"count": 1, proto: {"count": 1, "ports": [port]}},
-        "stun_queries": [{"magic": magic, "tid": tid_lo, "len": len_, "type": type_}],
+        "stun_queries": [{"magic": magic, "tid": tid, "len": len_, "type": type_}],
     }
     return {
         "ports": [


### PR DESCRIPTION
This adds the detection of STUN requests over UDP based on two regex : 

![2021-10-13-172530_666x69_scrot](https://user-images.githubusercontent.com/3105926/137164936-f5345141-88dd-4f8e-8c45-7d22bf61be22.png)

**Note**: it requires to enable inspection for every incomping UDP packet with a payload ; maybe this is not something we want because of overhead?
```
redef udp_content_deliver_all_orig = T;
```
A compromise could be to enable only for known STUN ports (*e.g.*, 3478).