### PR TITLE
Passive: fix DNS_BLACKLIST updates

### DIFF
--- a/ivre/db/__init__.py
+++ b/ivre/db/__init__.py
@@ -53,7 +53,7 @@ except ImportError:
     USE_CLUSTER = False
 
 
-from ivre import config, geoiputils, nmapout, utils, xmlnmap, flow
+from ivre import config, geoiputils, nmapout, passive, utils, xmlnmap, flow
 from ivre.active.data import (
     ALIASES_TABLE_ELEMS,
     merge_host_docs,
@@ -3175,14 +3175,15 @@ class DBPassive(DB):
     def _update_dns_blacklist(old_spec):
         """Create a new dns blacklist entry based on the value of
         the old dns entry"""
-        spec = {}
         dnsbl_val = old_spec["value"]
-        spec["recontype"] = "DNS_BLACKLIST"
-        spec["value"] = old_spec["addr"]
-        spec["source"] = "%s-%s" % (dnsbl_val.split(".", 4)[4], old_spec["source"])
-        spec["addr"] = ".".join(dnsbl_val.split(".")[3::-1])
-        spec["count"] = old_spec["count"]
-        return spec
+        return {
+            "recontype": "DNS_BLACKLIST",
+            "value": old_spec["addr"],
+            "source": "%s-%s" % (dnsbl_val.split(".", 4)[4], old_spec["source"]),
+            "addr": ".".join(dnsbl_val.split(".")[3::-1]),
+            "count": old_spec["count"],
+            "schema_version": passive.SCHEMA_VERSION,
+        }
 
     def update_dns_blacklist(self):
         """Update the current database to detect blacklist domains.

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -62,6 +62,13 @@ HTTPD_PORT = 18080
 HTTPD_HOSTNAME = socket.gethostname()
 
 
+# See https://bugs.python.org/issue45235
+PYTHON_BUG_45235 = {
+    (3, 9, 8),
+}
+HAS_PYTHON_BUG_45235 = sys.version_info[:3] in PYTHON_BUG_45235
+
+
 # http://schinckel.net/2013/04/15/capture-and-test-sys.stdout-sys.stderr-in-unittest.testcase/
 @contextmanager
 def capture(function, *args, **kwargs):
@@ -4782,33 +4789,34 @@ class IvreTests(unittest.TestCase):
         # One entry in test should actually be one entry at the end.
         self.check_value("view_count_active", len(out.splitlines()))
 
-        # Test passive filters
-        # FIXME : positionnal IP filter is broken
-        # ret, out, _ = RUN(["ivre", "db2view", "--test", "passive",
-        #                    "10.0.0.1"])
-        ret, out, _ = RUN(
-            ["ivre", "db2view", "--test", "passive", "--net", "192.168.0.0/16"]
-        )
-        self.assertEqual(ret, 0)
-        self.check_value("view_test_network", len(out.splitlines()))
-        ret, out, _ = RUN(
-            [
-                "ivre",
-                "db2view",
-                "--test",
-                "passive",
-                "--range",
-                "192.168.0.0",
-                "192.168.255.255",
-            ]
-        )
-        self.assertEqual(ret, 0)
-        self.check_value("view_test_range", len(out.splitlines()))
-        ret, out, _ = RUN(
-            ["ivre", "db2view", "--test", "passive", "--host", "10.0.0.1"]
-        )
-        self.assertEqual(ret, 0)
-        self.assertEqual(len(out.splitlines()), 1)
+        if not HAS_PYTHON_BUG_45235:
+            # Test passive filters
+            # FIXME : positionnal IP filter is broken
+            # ret, out, _ = RUN(["ivre", "db2view", "--test", "passive",
+            #                    "10.0.0.1"])
+            ret, out, _ = RUN(
+                ["ivre", "db2view", "--test", "passive", "--net", "192.168.0.0/16"]
+            )
+            self.assertEqual(ret, 0)
+            self.check_value("view_test_network", len(out.splitlines()))
+            ret, out, _ = RUN(
+                [
+                    "ivre",
+                    "db2view",
+                    "--test",
+                    "passive",
+                    "--range",
+                    "192.168.0.0",
+                    "192.168.255.255",
+                ]
+            )
+            self.assertEqual(ret, 0)
+            self.check_value("view_test_range", len(out.splitlines()))
+            ret, out, _ = RUN(
+                ["ivre", "db2view", "--test", "passive", "--host", "10.0.0.1"]
+            )
+            self.assertEqual(ret, 0)
+            self.assertEqual(len(out.splitlines()), 1)
 
         print("Counting")
         view_count = 0


### PR DESCRIPTION
This PR also comes with a workaround for #1213. A limited set of tests are skipped with Python 3.9.8.