### PR TITLE
Fix crash when pyOpenSSL is not installed

### DIFF
--- a/.github/actions/install/install.sh
+++ b/.github/actions/install/install.sh
@@ -28,6 +28,12 @@ mkdir -p usr/local/wireshark/share/wireshark
 wget -q https://raw.githubusercontent.com/wireshark/wireshark/master/manuf -O usr/local/wireshark/share/wireshark/manuf
 wget -q -O - https://github.com/ivre/ivre-test-samples/archive/0951ba6fc0eee158546e04fbce84c560950023d6.tar.gz | tar --transform='s#^ivre-test-samples-[^/]*/*#./#' -zxf -
 
+USE_PYOPENSSL="$((RANDOM % 2))"
+echo "USE_PYOPENSSL: ${USE_PYOPENSSL}"
+if [ "${USE_PYOPENSSL}" = "0" ]; then
+    pip uninstall -y pyOpenSSL
+fi
+
 zeek_v[0]="3.0.6"
 zeek_v[1]="3.1.3"
 zeek_v[2]="3.2.4"

--- a/ivre/utils.py
+++ b/ivre/utils.py
@@ -2346,7 +2346,7 @@ else:
         pubkey = decode_b64(b"".join(pubkey.splitlines()[1:-1]))
         for hashtype in ["md5", "sha1", "sha256"]:
             result["pubkey"][hashtype] = hashlib.new(hashtype, pubkey).hexdigest()
-        result["pubkey"]["raw"] = encode_b64(pubkey)
+        result["pubkey"]["raw"] = encode_b64(pubkey).decode()
         return result
 
 

--- a/ivre/utils.py
+++ b/ivre/utils.py
@@ -2074,79 +2074,6 @@ PUBKEY_TYPES = {
 PUBKEY_REV_TYPES = dict((val, key) for key, val in PUBKEY_TYPES.items())
 
 
-def _parse_cert_subject(subject: str) -> Generator[Tuple[str, str], None, None]:
-    status = 0
-    curkey = []
-    curvalue = []
-    for char in subject:
-        if status == -1:
-            # reading space before the key
-            if char == " ":
-                continue
-            curkey.append(char)
-            status += 1
-        elif status == 0:
-            # reading key
-            if char == " ":
-                status += 1
-                continue
-            if char == "=":
-                status += 2
-                continue
-            curkey.append(char)
-        elif status == 1:
-            # reading '='
-            if char != "=":
-                return
-            status += 1
-        elif status == 2:
-            # reading space after '='
-            if char == " ":
-                continue
-            # reading beginning of value
-            if char == '"':
-                status += 2
-                continue
-            curvalue.append(char)
-            status += 1
-        elif status == 3:
-            # reading value without quotes
-            if char == ",":
-                yield "".join(curkey), "".join(curvalue)
-                curkey = []
-                curvalue = []
-                status = -1
-                continue
-            curvalue.append(char)
-        elif status == 4:
-            # reading value with quotes
-            if char == '"':
-                status -= 1
-                continue
-            if char == "\\":
-                status += 1
-                continue
-            curvalue.append(char)
-        elif status == 5:
-            curvalue.append(char)
-            status -= 1
-    yield "".join(curkey), "".join(curvalue)
-
-
-def _parse_subject(subject: osslc.X509Name) -> Tuple[str, Dict[str, str]]:
-    """Parses an X509Name object (from pyOpenSSL module) and returns a
-    text and a dict suitable for use by get_cert_info().
-
-    """
-    components = []
-    for k, v in subject.get_components():
-        k = printable(k).decode()
-        v = printable(v).decode()
-        k = _CERTKEYS.get(k, k)
-        components.append((k, v))
-    return "/".join("%s=%s" % kv for kv in components), dict(components)
-
-
 if STRPTIME_SUPPORTS_TZ:
 
     def _parse_datetime(value: bytes) -> Optional[datetime.datetime]:
@@ -2170,6 +2097,19 @@ else:
 
 
 if USE_PYOPENSSL:
+
+    def _parse_subject(subject: osslc.X509Name) -> Tuple[str, Dict[str, str]]:
+        """Parses an X509Name object (from pyOpenSSL module) and returns a
+        text and a dict suitable for use by get_cert_info().
+
+        """
+        components = []
+        for k, v in subject.get_components():
+            k = printable(k).decode()
+            v = printable(v).decode()
+            k = _CERTKEYS.get(k, k)
+            components.append((k, v))
+        return "/".join("%s=%s" % kv for kv in components), dict(components)
 
     def get_cert_info(cert: bytes) -> Dict[str, Any]:
         """Extract info from a certificate (hash values, issuer, subject,
@@ -2231,6 +2171,64 @@ if USE_PYOPENSSL:
 
 
 else:
+
+    def _parse_cert_subject(subject: str) -> Generator[Tuple[str, str], None, None]:
+        status = 0
+        curkey = []
+        curvalue = []
+        for char in subject:
+            if status == -1:
+                # reading space before the key
+                if char == " ":
+                    continue
+                curkey.append(char)
+                status += 1
+            elif status == 0:
+                # reading key
+                if char == " ":
+                    status += 1
+                    continue
+                if char == "=":
+                    status += 2
+                    continue
+                curkey.append(char)
+            elif status == 1:
+                # reading '='
+                if char != "=":
+                    return
+                status += 1
+            elif status == 2:
+                # reading space after '='
+                if char == " ":
+                    continue
+                # reading beginning of value
+                if char == '"':
+                    status += 2
+                    continue
+                curvalue.append(char)
+                status += 1
+            elif status == 3:
+                # reading value without quotes
+                if char == ",":
+                    yield "".join(curkey), "".join(curvalue)
+                    curkey = []
+                    curvalue = []
+                    status = -1
+                    continue
+                curvalue.append(char)
+            elif status == 4:
+                # reading value with quotes
+                if char == '"':
+                    status -= 1
+                    continue
+                if char == "\\":
+                    status += 1
+                    continue
+                curvalue.append(char)
+            elif status == 5:
+                curvalue.append(char)
+                status -= 1
+        yield "".join(curkey), "".join(curvalue)
 
     def get_cert_info(cert: bytes) -> Dict[str, Any]:
         """Extract info from a certificate (hash values, issuer, subject,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -4170,11 +4170,12 @@ class IvreTests(unittest.TestCase):
         self.assertEqual(ivre.utils.guess_srv_port(67, 68, proto="udp"), 1)
         self.assertEqual(ivre.utils.guess_srv_port(65432, 80), -1)
         self.assertEqual(ivre.utils.guess_srv_port(666, 666), 0)
-        # Certificate argument parsing
-        self.assertCountEqual(
-            list(ivre.utils._parse_cert_subject('O = "Test\\", Inc."')),
-            [("O", 'Test", Inc.')],
-        )
+        if not ivre.utils.USE_PYOPENSSL:
+            # Certificate argument parsing
+            self.assertCountEqual(
+                list(ivre.utils._parse_cert_subject('O = "Test\\", Inc."')),
+                [("O", 'Test", Inc.')],
+            )
 
         # ipcalc tool
         res, out, _ = RUN(["ivre", "ipcalc", "192.168.0.0/16"])


### PR DESCRIPTION
This is another fix for #1216.
We have to decide whether pyOpenSSL should be mandatory but in the meantime, let's at least do this!