### PR TITLE
Revert "WebUI - Prevent content to be hidden in preview mode"

### DIFF
--- a/web/static/ivre/ivre.css
+++ b/web/static/ivre/ivre.css
@@ -139,7 +139,7 @@ form {
 }
 
 .preview {
-    overflow: scroll;
+    overflow: hidden;
     border: 1px solid rgba(0, 0, 0, 0.1);
     max-height: 150px;
 }


### PR DESCRIPTION
Reverts ivre/ivre#1401
My mistake, I had not tested that with Chrome / Chromium and the result is clearly less good than the previous one.
Sorry @psyray, I hope we'll find another way to fix / handle #1398.