### PR TITLE
Docker/client: fix Nmap scripts install & patches

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -63,8 +63,8 @@ RUN tar jxf phantomjs-2.1.1-linux-x86_64.tar.bz2 phantomjs-2.1.1-linux-x86_64/bi
 RUN for d in /usr /usr/local; do \
         d="$d/share/ivre/patches"; \
         [ -d "$d" ] && ( \
-            cp $d/nmap/scripts/*.nse /usr/local/share/nmap/scripts; \
-            cd /usr/local/share/nmap/; \
+            cp $d/nmap/scripts/*.nse /usr/share/nmap/scripts; \
+            cd /usr/share/nmap/; \
             for p in $d/nmap/*.patch; do \
                  patch -p0 < $p; \
             done ; \


### PR DESCRIPTION
After #1416, Nmap is installed under `/usr`, not `/usr/local`. The Nmap scripts & patches provided with IVRE are not currently correctly installed, which caused the issue reported by @jallphin.
Fixes #1439.