### PR TITLE
Fix bug when scan result file is empty

### DIFF
--- a/ivre/db/__init__.py
+++ b/ivre/db/__init__.py
@@ -2186,6 +2186,9 @@ class DBNmap(DBActive):
                     )
             elif fchar == b"[":
                 store_scan_function = self.store_scan_json_dismap
+            elif fchar == b"":
+                # empty input file
+                return lambda a, b: True
             else:
                 raise ValueError(  # pylint: disable=raise-missing-from
                     f"Unknown file type {fname}"


### PR DESCRIPTION
When an empty file is being imported with  `ivre scan2db`, the following exception occur:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/ivre/db/__init__.py", line 2144, in store_scan
    store_scan_function = {
KeyError: b''

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/ivre/tools/scan2db.py", line 146, in main
    if database.store_scan(
  File "/usr/local/lib/python3.9/dist-packages/ivre/db/__init__.py", line 2190, in store_scan
    raise ValueError(  # pylint: disable=raise-missing-from
ValueError: Unknown file type /tmp/empty_file
```

This PR aims to fix this by silently ignoring the import of empty files.

This is arguable, as one may want to throw an exception when importing an empty file.
On the other hand, when importing lots of result files at once, it would be nice to avoid this exception (to be able to focus on other exceptions).

Feel free to reject this PR if you disagree.