### PR TITLE
Fix IVRE w/ Python 3.9 (at least)

### DIFF
--- a/.github/workflows/mongodb.yml
+++ b/.github/workflows/mongodb.yml
@@ -1,5 +1,5 @@
 # This file is part of IVRE.
-# Copyright 2011 - 2022 Pierre LALET <pierre@droids-corp.org>
+# Copyright 2011 - 2023 Pierre LALET <pierre@droids-corp.org>
 #
 # IVRE is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         # https://docs.mongodb.com/drivers/pymongo/#compatibility
-        python-version: ['3.7', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         mongodb-version: ['3.6', '5.0']
 
     steps:

--- a/.github/workflows/tinydb.yml
+++ b/.github/workflows/tinydb.yml
@@ -1,5 +1,5 @@
 # This file is part of IVRE.
-# Copyright 2011 - 2022 Pierre LALET <pierre@droids-corp.org>
+# Copyright 2011 - 2023 Pierre LALET <pierre@droids-corp.org>
 #
 # IVRE is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
 

--- a/ivre/tools/version.py
+++ b/ivre/tools/version.py
@@ -53,7 +53,12 @@ def list_plugins() -> Optional[Dict[str, List[Tuple[str, Optional[str]]]]]:
         return None
     modules: Dict[str, Set[str]] = {}
     for category in ["view"]:
-        for entry_point in entry_points(group=f"ivre.plugins.{category}"):
+        group = f"ivre.plugins.{category}"
+        try:
+            my_entry_points = entry_points(group=group)
+        except TypeError:
+            my_entry_points = entry_points().get(group, [])  # type: ignore
+        for entry_point in my_entry_points:
             modules.setdefault(category, set()).add(entry_point.module)
     return {
         category: sorted((module, get_version(module)) for module in sorted(modules))

--- a/ivre/view.py
+++ b/ivre/view.py
@@ -49,7 +49,11 @@ from ivre.xmlnmap import add_service_hostname
 
 
 def load_plugins():
-    for entry_point in entry_points(group="ivre.plugins.view"):
+    try:
+        my_entry_points = entry_points(group="ivre.plugins.view")
+    except TypeError:
+        my_entry_points = entry_points().get("ivre.plugins.view", [])
+    for entry_point in my_entry_points:
         if entry_point.name.startswith("_install_"):
             entry_point.load()(globals())
 


### PR DESCRIPTION
MongoDB & TinyDB backends are now tested with all supported Python versions.

Reported by @cybermyber on Gitter.