### PR TITLE
fix(webui): display screenshots when they exist

### DIFF
--- a/web/static/templates/view-hosts.html
+++ b/web/static/templates/view-hosts.html
@@ -1,6 +1,6 @@
 <!--
   This file is part of IVRE.
-  Copyright 2011 - 2022 Pierre LALET <pierre@droids-corp.org>
+  Copyright 2011 - 2023 Pierre LALET <pierre@droids-corp.org>
 
   IVRE is free software: you can redistribute it and/or modify it
   under the terms of the GNU General Public License as published by
@@ -62,7 +62,7 @@
     <div port-summary=""></div>
   </dt>
   <dd ng-repeat-end ng-if="port.port !== -1">
-    <div ng-if="::port.service_name"
+    <div ng-if="::port.service_name || port.screenshot"
 	 class="result-service"
 	 service-summary="">
     </div>

--- a/web/static/templates/view-ports-only.html
+++ b/web/static/templates/view-ports-only.html
@@ -1,6 +1,6 @@
 <!--
   This file is part of IVRE.
-  Copyright 2011 - 2020 Pierre LALET <pierre@droids-corp.org>
+  Copyright 2011 - 2023 Pierre LALET <pierre@droids-corp.org>
 
   IVRE is free software: you can redistribute it and/or modify it
   under the terms of the GNU General Public License as published by
@@ -29,7 +29,7 @@
     </dt>
     <dd ng-repeat-end
 	ng-if="port.port !== -1 && port_display_mode_needed_port(port.protocol, port.port)">
-      <div ng-if="::port.service_name"
+      <div ng-if="::port.service_name || port.screenshot"
 	   class="result-service"
 	   service-summary="">        
       </div>

--- a/web/static/templates/view-screenshots-only.html
+++ b/web/static/templates/view-screenshots-only.html
@@ -1,6 +1,6 @@
 <!--
   This file is part of IVRE.
-  Copyright 2011 - 2020 Pierre LALET <pierre@droids-corp.org>
+  Copyright 2011 - 2023 Pierre LALET <pierre@droids-corp.org>
 
   IVRE is free software: you can redistribute it and/or modify it
   under the terms of the GNU General Public License as published by
@@ -28,8 +28,7 @@
       <div port-summary=""></div>
     </dt>
     <dd ng-repeat-end ng-if="port.port !== -1 && port.screenshot">
-      <div ng-if="::port.service_name"
-	   class="result-service"
+      <div class="result-service"
 	   service-summary="">
       </div>
     </dd>

--- a/web/static/templates/view-scripts-only.html
+++ b/web/static/templates/view-scripts-only.html
@@ -1,6 +1,6 @@
 <!--
   This file is part of IVRE.
-  Copyright 2011 - 2015 Pierre LALET <pierre.lalet@cea.fr>
+  Copyright 2011 - 2023 Pierre LALET <pierre@droids-corp.org>
 
   IVRE is free software: you can redistribute it and/or modify it
   under the terms of the GNU General Public License as published by
@@ -29,7 +29,7 @@
     </dt>
     <dd ng-repeat-end
 	ng-if="port.port !== -1 && script_display_mode_needed_scripts_group(port.scripts)">
-      <div ng-if="::port.service_name"
+      <div ng-if="::port.service_name || port.screenshot"
 	   class="result-service"
 	   service-summary="">
       </div>

--- a/web/static/templates/view-services-only.html
+++ b/web/static/templates/view-services-only.html
@@ -1,6 +1,6 @@
 <!--
   This file is part of IVRE.
-  Copyright 2011 - 2018 Pierre LALET <pierre.lalet@cea.fr>
+  Copyright 2011 - 2023 Pierre LALET <pierre@droids-corp.org>
 
   IVRE is free software: you can redistribute it and/or modify it
   under the terms of the GNU General Public License as published by
@@ -29,8 +29,7 @@
     </dt>
     <dd ng-repeat-end
 	ng-if="port.port !== -1 && service_display_mode_needed_port(port.service_name)">
-      <div ng-if="::port.service_name"
-	   class="result-service"
+      <div class="result-service"
 	   service-summary="">        
       </div>
       <div ng-repeat="script in ::port.scripts"

--- a/web/static/templates/view-vulnerabilities-only.html
+++ b/web/static/templates/view-vulnerabilities-only.html
@@ -1,6 +1,6 @@
 <!--
   This file is part of IVRE.
-  Copyright 2011 - 2018 Pierre LALET <pierre.lalet@cea.fr>
+  Copyright 2011 - 2023 Pierre LALET <pierre@droids-corp.org>
 
   IVRE is free software: you can redistribute it and/or modify it
   under the terms of the GNU General Public License as published by
@@ -29,7 +29,7 @@
     </dt>
     <dd ng-repeat-end
 	ng-if="port.port !== -1 && script_display_mode_needed_scripts_group(port.scripts, true)">
-      <div ng-if="::port.service_name"
+      <div ng-if="::port.service_name || port.screenshot"
 	   class="result-service"
 	   service-summary="">
       </div>


### PR DESCRIPTION
Before that fix, screenshots would only be displayed when a `service_name` field existed for the port.