### PR TITLE
Nmap scripts: add RDP screenshot using scrying

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -32,6 +32,13 @@ RUN apt-get -q update && \
     alien ./nmap.rpm && \
     dpkg -i ./nmap*.deb
 
+# Build scrying for RDP screenshots with Nmap
+ADD https://github.com/nccgroup/scrying/archive/refs/heads/main.tar.gz ./main.tar.gz
+RUN apt -qy --no-install-recommends install cargo ca-certificates pkg-config libssl-dev && \
+    tar zxf main.tar.gz && \
+    cd scrying-main && \
+    cargo build --release
+
 
 ARG TAG=latest
 FROM ivre/base:${TAG}
@@ -69,6 +76,9 @@ RUN apt-get -q update && \
 
 # "Install" phantomjs for our http-screenshot NSE script replacement
 COPY --from=builder /phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs
+
+# "Install" scrying for our rdp-screenshot NSE script
+COPY --from=builder /scrying-main/target/release/scrying /usr/local/bin/scrying
 
 # Add our *-screenshot NSE scripts  # /usr/local/share/ivre/patches
 RUN apt-get -q update && \

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -60,11 +60,11 @@ RUN apt-get -q update && \
 COPY --from=builder /usr/bin/nmap /usr/bin/nmap
 COPY --from=builder /usr/share/nmap /usr/share/nmap
 
-# Install Zeek - Debian Testing because Debian_12 does not exist for now
+# Install Zeek
 RUN apt-get -q update && \
     apt-get -qy --no-install-recommends install gnupg wget ca-certificates && \
-    echo 'deb http://download.opensuse.org/repositories/security:/zeek/Debian_Testing/ /' > /etc/apt/sources.list.d/zeek.list && \
-    wget -qO - https://download.opensuse.org/repositories/security:zeek/Debian_Testing/Release.key | gpg --dearmor > /etc/apt/trusted.gpg.d/security_zeek.gpg && \
+    echo 'deb http://download.opensuse.org/repositories/security:/zeek/Debian_12/ /' > /etc/apt/sources.list.d/zeek.list && \
+    wget -qO - https://download.opensuse.org/repositories/security:zeek/Debian_12/Release.key | gpg --dearmor > /etc/apt/trusted.gpg.d/security_zeek.gpg && \
     apt-get -q update && apt-get -qy --no-install-recommends install zeek && \
     apt-get -qy --purge autoremove gnupg wget ca-certificates && \
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/patches/nmap/scripts/rdp-screenshot.nse
+++ b/patches/nmap/scripts/rdp-screenshot.nse
@@ -1,0 +1,61 @@
+-- This file is part of IVRE.
+-- Copyright 2011 - 2023 Pierre LALET <pierre.lalet@cea.fr>
+--
+-- IVRE is free software: you can redistribute it and/or modify it
+-- under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- IVRE is distributed in the hope that it will be useful, but WITHOUT
+-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+-- or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+-- License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with IVRE. If not, see <http://www.gnu.org/licenses/>.
+
+local shortport = require "shortport"
+local stdnse = require "stdnse"
+
+description = [[
+
+Gets a screenshot from an RDP server using `scrying`.
+
+`scrying` tool must me installed somewhere in $PATH (see
+<https://github.com/nccgroup/scrying>).
+
+]]
+
+author = "Pierre Lalet"
+license = "GPLv3"
+categories = {"discovery", "safe", "screenshot"}
+
+---
+-- @usage
+-- nmap -n -p 3389 --script rdp-screenshot 1.2.3.4
+--
+-- @args rdp-screenshot.timeout timeout for the import process
+--       (default: 600s)
+--
+-- @output
+-- PORT     STATE SERVICE
+-- 3389/tcp open  ms-wbt-server
+-- |_rdp-screenshot: Saved to screenshot-1.2.3.4-3389.png
+
+local function sh_timeout(cmd, timeout)
+  return ("%s & CPID=${!}; (sleep %d; kill -9 ${CPID} 2>/dev/null) & SPID=${!}; wait ${CPID} 2>/dev/null; kill -- -${SPID} 2>/dev/null"):format(cmd, timeout)
+end
+
+
+portrule = shortport.port_or_service(3389, "ms-wbt-server")
+
+
+action = function(host, port)
+  local fname = ("%s-%d.png"):format(host.ip, port.number)
+  local timeout = tonumber(stdnse.get_script_args(SCRIPT_NAME .. '.timeout')) or 600
+  os.execute(sh_timeout(("scrying -t rdp://%s:%d/ --disable-report --output ."):format(
+		 host.ip, port.number), timeout))
+  if os.rename(("rdp/%s"):format(fname), ("screenshot-%s"):format(fname)) then
+    return ("Saved to %s"):format(("screenshot-%s"):format(fname))
+  end
+end

--- a/patches/nmap/scripts/vnc-screenshot.nse
+++ b/patches/nmap/scripts/vnc-screenshot.nse
@@ -40,7 +40,7 @@ categories = {"discovery", "safe", "screenshot"}
 -- @output
 -- PORT     STATE SERVICE
 -- 5900/tcp open  http
--- |_http-screenshot: Saved to screenshot-1.2.3.4-5900.jpg
+-- |_vnc-screenshot: Saved to screenshot-1.2.3.4-5900.jpg
 
 portrule = shortport.port_or_service(5900, "vnc")
 


### PR DESCRIPTION
TODO:
- [x] fix tests after wireshark/wireshark@b4a421cf8206dc9a675fbc58500d1a625869e77a
  - see #1557
- [x] install [nccgroup/scrying](https://github.com/nccgroup/scrying) in `ivre/client` docker image