### PR TITLE
docker/web: limit the headers sent to UWSGI container

### DIFF
--- a/docker/web/nginx-default-site
+++ b/docker/web/nginx-default-site
@@ -32,6 +32,8 @@ server {
         include uwsgi_params;
         uwsgi_pass ivreuwsgi:3031;
         uwsgi_param REMOTE_USER $remote_user;
+        uwsgi_param HTTP_Cookie "";
+        uwsgi_param HTTP_User_Agent "";
     }
 
     location ~ ^/dokuwiki/.*\.php$ {


### PR DESCRIPTION
Cookies may sometimes be large and contribute to exceed the `buffer-size` accepted by UWSGI (4096 bytes by default). Since neither `Cookie` or `User-Agent` are used in the Python application, this PR prevents them from being sent by the Nginx proxy.

If you are using IVRE behind CloudFlare for example, this may help!