### PR TITLE
CLI/db2view: do not use parallel insert on file-backed DBs

### DIFF
--- a/ivre/db/__init__.py
+++ b/ivre/db/__init__.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # This file is part of IVRE.
-# Copyright 2011 - 2023 Pierre LALET <pierre@droids-corp.org>
+# Copyright 2011 - 2024 Pierre LALET <pierre@droids-corp.org>
 #
 # IVRE is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -90,6 +90,7 @@ class DB:
     """
 
     globaldb = None
+    parallel_insert = True
     ipaddr_fields = []
     datetime_fields = []
     list_fields = []

--- a/ivre/db/sql/sqlite.py
+++ b/ivre/db/sql/sqlite.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # This file is part of IVRE.
-# Copyright 2011 - 2021 Pierre LALET <pierre@droids-corp.org>
+# Copyright 2011 - 2024 Pierre LALET <pierre@droids-corp.org>
 #
 # IVRE is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -35,6 +35,11 @@ from ivre.db.sql import SQLDB, SQLDBPassive
 
 
 class SqliteDB(SQLDB):
+
+    """A DB using SQLite backend"""
+
+    parallel_insert = False
+
     def __init__(self, url):
         super().__init__(url)
         # url.geturl() removes two necessary '/' from url

--- a/ivre/db/tiny.py
+++ b/ivre/db/tiny.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # This file is part of IVRE.
-# Copyright 2011 - 2023 Pierre LALET <pierre@droids-corp.org>
+# Copyright 2011 - 2024 Pierre LALET <pierre@droids-corp.org>
 #
 # IVRE is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -69,6 +69,7 @@ class TinyDB(DB):
 
     """A DB using TinyDB backend"""
 
+    parallel_insert = False
     flt_empty = EMPTY_QUERY
     no_limit = None
 

--- a/ivre/tools/db2view.py
+++ b/ivre/tools/db2view.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
 # This file is part of IVRE.
-# Copyright 2011 - 2023 Pierre LALET <pierre@droids-corp.org>
+# Copyright 2011 - 2024 Pierre LALET <pierre@droids-corp.org>
 #
 # IVRE is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -149,9 +149,9 @@ def main() -> None:
             parser.error('Cannot use "passive" (no Passive database exists)')
         fltpass = db.passive.parse_args(args, fltpass)
         _from = [passive_to_view(fltpass, category=view_category)]
-    if args.test:
-        args.processes = 1
     outdb = db.view if args.to_db is None else DBView.from_url(args.to_db)
+    if args.test or not outdb.parallel_insert:
+        args.processes = 1
 
     # Output results
 

--- a/ivre/tools/runscans.py
+++ b/ivre/tools/runscans.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # This file is part of IVRE.
-# Copyright 2011 - 2022 Pierre LALET <pierre@droids-corp.org>
+# Copyright 2011 - 2024 Pierre LALET <pierre@droids-corp.org>
 #
 # IVRE is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -27,7 +27,6 @@ import argparse
 import atexit
 import fcntl
 import functools
-import multiprocessing
 import os
 import re
 import resource
@@ -37,6 +36,7 @@ import subprocess
 import sys
 import termios
 import time
+from multiprocessing import Pool
 from typing import Any, BinaryIO, Dict, List, Optional, Set, Tuple, Type
 
 import ivre.agent
@@ -416,7 +416,7 @@ def main() -> None:
             args.nmap_max_stack_size,
         )
     if args.output == "XMLFork":
-        with multiprocessing.Pool(processes=args.processes) as pool:
+        with Pool(processes=args.processes) as pool:
             call_nmap_single = functools.partial(
                 _call_nmap_single,
                 targets.infos["categories"][0],

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
 # This file is part of IVRE.
-# Copyright 2011 - 2024 Pierre LALET <pierre@droids-corp.org>
+# Copyright 2011 - 2023 Pierre LALET <pierre@droids-corp.org>
 #
 # IVRE is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -4905,10 +4905,7 @@ class IvreTests(unittest.TestCase):
         shutil.rmtree("output")
 
     def test_50_view(self):
-        if DATABASE == "tinydb":
-            processes = ["--processes", "1"]
-        else:
-            processes = random.choice([[], ["--processes", "1"]])
+        processes = random.choice([[], ["--processes", "1"]])
         print(f"Running db2view with {processes!r}")
         #
         # Web server tests


### PR DESCRIPTION
For now, this is only useful for TinyDB.

This reverts #1602 that was a short-term "solution".