### PR TITLE
Zeek/JA4: fix QUIC protocol detection

### DIFF
--- a/zeek/ivre/passiverecon/ja3.zeek
+++ b/zeek/ivre/passiverecon/ja3.zeek
@@ -241,7 +241,11 @@ event ssl_client_hello(c: connection, version: count, record_version: count, pos
         ja4_a += "t";
     }
     else if (proto == udp) {
+@if(Version::number >= 60100)
+        if (c?$quic || "QUIC" in c$service) {
+@else
         if ("QUIC" in c$service) {
+@endif
             ja4_a += "q";
         }
         else {


### PR DESCRIPTION
This will only work for Zeek >= 6.1

<!-- readthedocs-preview ivre start -->
----
📚 Documentation preview 📚: https://ivre--1638.org.readthedocs.build/en/1638/

<!-- readthedocs-preview ivre end -->