### PR TITLE
Zeek/JA4: do not use version from extension if it's in grease

### DIFF
--- a/zeek/ivre/passiverecon/ja3.zeek
+++ b/zeek/ivre/passiverecon/ja3.zeek
@@ -172,7 +172,13 @@ event ssl_extension_supported_versions(c: connection, is_orig: bool, versions: i
         if (! c?$ivreja3c) {
             c$ivreja3c = IvreJA3CStore();
         }
-        c$ivreja3c$version = versions[0];
+        for (i in versions) {
+            local value = versions[i];
+            if (value !in grease) {
+                c$ivreja3c$version = value;
+                break;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Bug spotted using capture from the JA4 project: [chrome-cloudflare-quic-with-secrets.pcapng](https://github.com/FoxIO-LLC/ja4/blob/977da74d8cf3ac66684bb5d2a92db2f82fc2f4b9/pcap/chrome-cloudflare-quic-with-secrets.pcapng).

<!-- readthedocs-preview ivre start -->
----
📚 Documentation preview 📚: https://ivre--1639.org.readthedocs.build/en/1639/

<!-- readthedocs-preview ivre end -->