### PR TITLE
Nmap/JA4: fix ja4_c with no signature algorithms

### DIFF
--- a/ivre/analyzer/ja3.py
+++ b/ivre/analyzer/ja3.py
@@ -166,9 +166,11 @@ def banner2scripts(
         "ssl-ja3-client": [structured_ja3],
     }
     ja4_b = hashlib.new("sha256", data=output_ja4_b.encode()).hexdigest()[:12]
-    ja4_c = hashlib.new(
-        "sha256", data=f"{output_ja4_c1}_{output_ja4_c2}".encode()
-    ).hexdigest()[:12]
+    if output_ja4_c2:
+        output_ja4_c = f"{output_ja4_c1}_{output_ja4_c2}"
+    else:
+        output_ja4_c = output_ja4_c1
+    ja4_c = hashlib.new("sha256", data=output_ja4_c.encode()).hexdigest()[:12]
     ja4 = f"{output_ja4_a}_{ja4_b}_{ja4_c}"
     script_ja4 = {
         "id": "ssl-ja4-client",


### PR DESCRIPTION
As explained by @lrstewart in FoxIO-LLC/ja4#146, JA4 [technical details](https://github.com/FoxIO-LLC/ja4/blob/main/technical_details/JA4.md#extension-hash) mention that:
> If there are no signature algorithms in the hello packet, then the string ends without an underscore and is hashed.

This is part of #1637. This is the equivalent of #1640 (which is for Zeek) for Python code for Nmap banner parsing.

<!-- readthedocs-preview ivre start -->
----
📚 Documentation preview 📚: https://ivre--1641.org.readthedocs.build/en/1641/

<!-- readthedocs-preview ivre end -->