### PR TITLE
refactor(ci): replace unmaintained PSQL action with built-in `services` setup

### DIFF
--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -27,8 +27,22 @@ jobs:
         python-version: ['3.7', '3.12']
         postgresql-version: ['12', '13']
 
-    steps:
+    services:
+      postgres:
+        image: postgres:${{ matrix.postgresql-version }}
+        env:
+          POSTGRES_DB: ivre
+          POSTGRES_PASSWORD: ivre
+          POSTGRES_USER: ivre
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
 
+    steps:
     - name: Git checkout
       uses: actions/checkout@v2
       with:
@@ -38,14 +52,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-
-    - name: Start PostgreSQL
-      uses: harmon758/postgresql-action@v1
-      with:
-        postgresql version: ${{ matrix.postgresql-version }}
-        postgresql db: ivre
-        postgresql user: ivre
-        postgresql password: ivre
 
     - run: pip install -r requirements-postgres.txt
 


### PR DESCRIPTION
This commit replaces unmaintained `harmon758/postgresql-action` action with built-in `services` to pop a PSQL container for testing purposes. As a bonus, it also brings container healthcheck to make sure we wait for database to be ready before proceeding to tests.

Taken from: https://docs.github.com/en/actions/use-cases-and-examples/using-containerized-services/creating-postgresql-service-containers

<!-- readthedocs-preview ivre start -->
----
📚 Documentation preview 📚: https://ivre--1664.org.readthedocs.build/en/1664/

<!-- readthedocs-preview ivre end -->