### PR TITLE
Add zeek command to default shell path

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -69,6 +69,8 @@ RUN apt-get -q update && \
     apt-get -qy --purge autoremove gnupg wget && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
+ENV PATH=/opt/zeek/bin:$PATH
+
 # Install p0f
 RUN apt-get -q update && \
     apt-get -qy --no-install-recommends install p0f && \


### PR DESCRIPTION
Add zeek commands located in /opt/zeek/bin to default shell path

<!-- readthedocs-preview ivre start -->
----
📚 Documentation preview 📚: https://ivre--1667.org.readthedocs.build/en/1667/

<!-- readthedocs-preview ivre end -->