### PR TITLE
Fix getwebdata downloads

### DIFF
--- a/ivre/config.py
+++ b/ivre/config.py
@@ -235,7 +235,7 @@ IPDATA_URLS = {
     # GeoLite2-* files using `ivre ipdata --import-all`. You should do
     # that if you get your files from Maxmind.
     "GeoLite2-dumps.tar.gz": "https://ivre.rocks/data/geolite/GeoLite2-dumps.tar.gz",
-    "iso3166.csv": "https://dev.maxmind.com/csv-files/codes/iso3166.csv",
+    "iso3166.csv": "https://dev.maxmind.com/static/csv/codes/iso3166.csv",
     # This one is not from maxmind -- see https://thyme.apnic.net/
     "BGP.raw": "https://thyme.apnic.net/current/data-raw-table",
 }

--- a/setup.py
+++ b/setup.py
@@ -214,7 +214,16 @@ setup(
         ),
         ("share/ivre/honeyd", ["data/.empty"]),
         ("share/ivre/geoip", ["data/.empty"]),
-        ("share/ivre/data", ["data/ike-vendor-ids", "data/manuf", "data/censys_scanners.txt", "data/ssigouvfr_scanners.txt", "data/ukncsc_scanners.txt"]),
+        (
+            "share/ivre/data",
+            [
+                "data/ike-vendor-ids",
+                "data/manuf",
+                "data/censys_scanners.txt",
+                "data/ssigouvfr_scanners.txt",
+                "data/ukncsc_scanners.txt",
+            ],
+        ),
         ("share/ivre/data/honeyd", ["data/honeyd/sshd"]),
         ("share/ivre/docker", ["docker/Vagrantfile"]),
         ("share/ivre/docker/agent", ["docker/agent/Dockerfile"]),

--- a/setup.py
+++ b/setup.py
@@ -214,7 +214,7 @@ setup(
         ),
         ("share/ivre/honeyd", ["data/.empty"]),
         ("share/ivre/geoip", ["data/.empty"]),
-        ("share/ivre/data", ["data/ike-vendor-ids", "data/manuf"]),
+        ("share/ivre/data", ["data/ike-vendor-ids", "data/manuf", "data/censys_scanners.txt", "data/ssigouvfr_scanners.txt", "data/ukncsc_scanners.txt"]),
         ("share/ivre/data/honeyd", ["data/honeyd/sshd"]),
         ("share/ivre/docker", ["docker/Vagrantfile"]),
         ("share/ivre/docker/agent", ["docker/agent/Dockerfile"]),


### PR DESCRIPTION
Hello,

This PR to fix `ivre getwebdata` command:
- update  "iso3166.csv" URL from "https://dev.maxmind.com/csv-files/codes/iso3166.csv" to "https://dev.maxmind.com/static/csv/codes/iso3166.csv"
- Embedded "censys_scanners.txt", "ssigouvfr_scanners.txt" and "ukncsc_scanners.txt" form https://github.com/ivre/ivre/pull/1620 into ivre python package


<!-- readthedocs-preview ivre start -->
----
📚 Documentation preview 📚: https://ivre--1668.org.readthedocs.build/en/1668/

<!-- readthedocs-preview ivre end -->