### PR TITLE
chore(setup.cfg): remove unneeded `metadata` and `sdist` sections

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,3 @@
-[metadata]
-description_file = README.md
-
-[sdist]
-formats=gztar
-owner=root
-group=root
-
 [rstcheck]
 ignore_directives=
     autobottle,


### PR DESCRIPTION
Towards https://github.com/ivre/ivre/issues/1678.

### Description

This commit removes `metadata` and `sdist` sections in `setup.cfg`:
- `metadata` section can be removed as README.md is already used in long_description argument in setup.py.
- `sdist` section can also be removed: `formats=gztar` entry can be removed as this is already the default value. I'm not sure why `owner=root` and `group=root` are needed, it has been added in f7a4002, it can probably be removed.

### How this has been tested ?
`python setup.py sdist` on master and on this branch produces the same sdist.

<!-- readthedocs-preview ivre start -->
----
📚 Documentation preview 📚: https://ivre--1679.org.readthedocs.build/en/1679/

<!-- readthedocs-preview ivre end -->