### PR TITLE
add env variable to set docker mount point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ build/
 dist/
 doc/_build
 docker/base-local/ivre.tar
+docker/ivre-share
+docker/var_lib_mongodb
+docker/dokuwiki_data
 ivre/VERSION
 ivre.egg-info/
 tests/samples*

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     image: mongo
     container_name: ivredb
     volumes:
-      - ./var_lib_mongodb:/data/db
+      - ${IVRE_MONGODB_PATH:-/var_lib_mongodb}:/data/db
     restart: always
   ivreuwsgi:
     image: ivre/web-uwsgi
@@ -29,13 +29,13 @@ services:
     depends_on:
       - ivredb
     volumes:
-      - ./dokuwiki_data:/var/www/dokuwiki/data
+      - ${IVRE_DOKUWIKI_PATH:-./dokuwiki_data}:/var/www/dokuwiki/data
   ivredoku:
     image: ivre/web-doku
     container_name: ivredoku
     restart: always
     volumes:
-      - ./dokuwiki_data:/var/www/dokuwiki/data
+      - ${IVRE_DOKUWIKI_PATH-./dokuwiki_data}:/var/www/dokuwiki/data
   ivreweb:
     image: ivre/web
     container_name: ivreweb
@@ -46,12 +46,12 @@ services:
       - ivreuwsgi
       - ivredoku
     volumes:
-      - ./dokuwiki_data:/var/www/dokuwiki/data
+      - ${IVRE_DOKUWIKI_PATH:-./dokuwiki_data}:/var/www/dokuwiki/data
   ivreclient:
     image: ivre/client
     container_name: ivreclient
     volumes:
-      - ./ivre-share:/ivre-share
+      - ${IVRE_SHARE_PATH:-./ivre-share}:/ivre-share
     depends_on:
       - ivredb
     stdin_open: true


### PR DESCRIPTION
Hello Pierre,

Here is a small modification to change the default docker compose mount configuration.
I would like to be able to set `IVRE_MONGODB_PATH`, `IVRE_DOKUWIKI_PATH` and `IVRE_SHARE_PATH` to change default docker host mount point.