### PR TITLE
Nuclei - CPE parsing

### DIFF
--- a/ivre/active/cpe.py
+++ b/ivre/active/cpe.py
@@ -29,32 +29,41 @@ from ivre.utils import LOGGER
 
 
 def cpe2dict(cpe_str: str) -> CpeDict:
-    """Helper function to parse CPEs. This is a very partial/simple parser.
+    """Parse a CPE string (2.2 or 2.3) into a dictionary.
+
+    Supports:
+    - CPE 2.2 format: cpe:/<type>:<vendor>:<product>:<version>
+    - CPE 2.3 format: cpe:2.3:<type>:<vendor>:<product>:<version>:...
 
     Raises:
-        ValueError if the cpe string is not parsable.
-
+        ValueError: If the CPE string is invalid or unsupported.
     """
-    # Remove prefix
-    if not cpe_str.startswith("cpe:/"):
-        raise ValueError("invalid cpe format (%s)\n" % cpe_str)
-    cpe_body = cpe_str[5:]
-    parts = cpe_body.split(":", 3)
-    nparts = len(parts)
-    if nparts < 2:
-        raise ValueError("invalid cpe format (%s)\n" % cpe_str)
-    cpe_type = parts[0]
-    cpe_vend = parts[1]
-    cpe_prod = parts[2] if nparts > 2 else ""
-    cpe_vers = parts[3] if nparts > 3 else ""
+    # Initialize default values
+    cpe_data = CpeDict(type="", vendor="", product="", version="")
 
-    ret: CpeDict = {
-        "type": cpe_type,
-        "vendor": cpe_vend,
-        "product": cpe_prod,
-        "version": cpe_vers,
-    }
-    return ret
+    # Parsing CPE
+    if cpe_str.startswith("cpe:2.3:"):
+        # CPE 2.3: Remove 'cpe:2.3:' and split
+        parts = cpe_str[8:].split(":")
+    elif cpe_str.startswith("cpe:/"):
+        # CPE 2.2: Remove 'cpe:/' and split
+        parts = cpe_str[5:].split(":")
+    else:
+        raise ValueError(f"Unsupported CPE format: {cpe_str}")
+
+    # Ensure the required fields exist
+    if len(parts) < 2:
+        raise ValueError(f"Invalid CPE format: {cpe_str}")
+
+    # Remove wildcard elements (*) after the version field
+    # Limit to 'type', 'vendor', 'product', 'version'
+    parts = parts[:4]
+    
+    # Assign values from the parsed parts
+    for key, value in zip(cpe_data.keys(), parts):
+        cpe_data[key] = value
+
+    return cpe_data
 
 
 def add_cpe_values(hostrec: dict[str, Any], path: str, cpe_values: list[str]) -> None:

--- a/ivre/db/__init__.py
+++ b/ivre/db/__init__.py
@@ -3100,6 +3100,12 @@ class DBNmap(DBActive):
                     "schema_version": xmlnmap.SCHEMA_VERSION,
                     "ports": [port_doc],
                 }
+                
+                # CPE parsing
+                cpeval = rec.get("metadata", {}).get("cpe")
+                if cpeval:
+                    add_cpe_values(host, f"ports.port:{port}", [cpeval])
+                    
                 if rec["template"] == "git-config":
                     repository = "%s:%d%s" % (addr, port, urlparse(url).path[:-6])
                     scripts.append(


### PR DESCRIPTION
Add CPE parsing capability for Nuclei output

Sample: [test_cpe.json](https://github.com/user-attachments/files/18278242/test_cpe.json)

**ivre scan2db -t**
`{"addr": "88.2.108.251", "cpes": [{"origins": ["ports.port:443"], "product": "wordpress", "type": "a", "vendor": "wordpress", "version": "2.3.4"}], "endtime": "2024-12-19 11:48:52", "ports": [{"port": 443, "protocol": "tcp", "scripts": [{"id": "http-nuclei", "nuclei": [{"name": "WordPressDetection", "severity": "info", "template": "wordpress-detection", "url": "https://test.fr/readme.html"}], "output": "[info] WordPress Detection found at https://test.fr/readme.html"}], "service_method": "probed", "service_name": "http", "service_tunnel": "ssl", "state_reason": "response", "state_state": "open"}], "schema_version": 22, "starttime": "2024-12-19 11:48:52", "state": "up"}
INFO:ivre:1 results imported.`

<!-- readthedocs-preview ivre start -->
----
📚 Documentation preview 📚: https://ivre--1685.org.readthedocs.build/en/1685/

<!-- readthedocs-preview ivre end -->