### PR TITLE
Auto-kill CI in Pull Requests on new commits

### DIFF
--- a/.github/workflows/elastic.yml
+++ b/.github/workflows/elastic.yml
@@ -18,6 +18,11 @@ name: Elasticsearch tests
 
 on: [push, pull_request]
 
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'master')}}
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -18,6 +18,11 @@ name: Linting tests
 
 on: [push, pull_request]
 
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'master')}}
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/maxmind.yml
+++ b/.github/workflows/maxmind.yml
@@ -18,6 +18,11 @@ name: Maxmind tests
 
 on: [push, pull_request]
 
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'master')}}
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/mongodb.yml
+++ b/.github/workflows/mongodb.yml
@@ -18,6 +18,11 @@ name: MongoDB tests
 
 on: [push, pull_request]
 
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'master')}}
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -18,6 +18,11 @@ name: PostgreSQL tests
 
 on: [push, pull_request]
 
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'master')}}
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/sqlite.yml
+++ b/.github/workflows/sqlite.yml
@@ -18,6 +18,11 @@ name: SQLite tests
 
 on: [push, pull_request]
 
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'master')}}
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/tinydb.yml
+++ b/.github/workflows/tinydb.yml
@@ -18,6 +18,11 @@ name: TinyDB tests
 
 on: [push, pull_request]
 
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'master')}}
+
 jobs:
   build:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
It's possible to make it so that CI jobs of a PR are automatically killed when a new commit is pushed to that PR.
This is very useful: if you see jobs starting to fail and you push a fix, you don't have to wait for the previous failing CI build to finish.

See https://github.com/secdev/scapy/pull/4648