### PR TITLE
Active: enhance X509 cert support from httpx & tlsx

### DIFF
--- a/ivre/activecli.py
+++ b/ivre/activecli.py
@@ -22,11 +22,7 @@ import os
 import sys
 from collections import OrderedDict
 from collections.abc import Callable, Iterable
-from typing import (
-    Any,
-    TextIO,
-    cast,
-)
+from typing import Any, TextIO, cast
 from xml.sax import saxutils
 
 from ivre import graphroute, utils

--- a/ivre/tags/__init__.py
+++ b/ivre/tags/__init__.py
@@ -22,11 +22,7 @@
 import os
 from bisect import bisect_left
 from collections.abc import Callable, Generator, Iterable
-from typing import (
-    Any,
-    TypeVar,
-    cast,
-)
+from typing import Any, TypeVar, cast
 
 from ivre.config import DATA_PATH
 from ivre.plugins import load_plugins

--- a/ivre/tools/__init__.py
+++ b/ivre/tools/__init__.py
@@ -19,8 +19,8 @@
 
 """This sub-module contains functions to implement ivre commands."""
 
-from itertools import chain
 from collections.abc import Callable
+from itertools import chain
 from typing import cast
 
 from ivre.plugins import load_plugins


### PR DESCRIPTION
For httpx, use -tls-grab to add tlsx data.

For tlsx, this patch uses cert data when the raw cert is not included (-cert option)