### PR TITLE
Fixed censys url and extraction

### DIFF
--- a/ivre/tools/getwebdata.py
+++ b/ivre/tools/getwebdata.py
@@ -130,7 +130,7 @@ URLS: list[tuple[str, str, Callable[[BinaryIO, BinaryIO], None]]] = [
         functools.partial(generic_processor, generic_ipaddr_extractor),
     ),
     (
-        "https://support.censys.io/hc/en-us/articles/360043177092-from-faq",
+        "https://docs.censys.com/docs/opt-out-of-data-collection",
         os.path.join(config.DATA_PATH, "censys_scanners.txt"),
         functools.partial(generic_processor, censys_net_extractor),
     ),


### PR DESCRIPTION
Changed the old censys url to the new one (https://docs.censys.com/docs/opt-out-of-data-collection)
Changed the way IPs are extracted as the new page has just one juge code block instead of one per IP